### PR TITLE
Fixed issue with click link in centered text

### DIFF
--- a/FTCoreText/FTCoreTextStyle.h
+++ b/FTCoreText/FTCoreTextStyle.h
@@ -34,7 +34,7 @@
 typedef void (^FTCoreTextCallbackBlock)(NSDictionary *info);
 
 
-typedef NS_ENUM(uint8_t, FTCoreTextAlignement)  {
+typedef NS_ENUM(NSInteger, FTCoreTextAlignement)  {
     FTCoreTextAlignementLeft = 0,
 	FTCoreTextAlignementRight = 1,
 	FTCoreTextAlignementCenter = 2,

--- a/FTCoreText/FTCoreTextView.m
+++ b/FTCoreText/FTCoreTextView.m
@@ -511,7 +511,7 @@ CTFontRef CTFontCreateFromUIFont(UIFont *font)
 				
 				for (NSString *key in urlsKeys) {
 					NSRange range = NSRangeFromString(key);
-					if (index >= range.location && index < range.location + range.length) {
+					if (index >= range.location && index <= range.location + range.length) {
 						NSURL *url = [_URLs objectForKey:key];
 						if (url) [returnedDict setObject:url forKey:FTCoreTextDataURL];
 						


### PR DESCRIPTION
If link was centered in the textview then only half the text was clickable. This fix resolves the issue.